### PR TITLE
Bugfix: follow rollbar redirects

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { https } = require('https');
+const { http } = require('follow-redirects');
 const { execSync } = require('child_process');
 
 class ServerlessPlugin {
@@ -43,7 +43,7 @@ class ServerlessPlugin {
 
       const environment = this.options.stage;
 
-      const request = https.request({
+      const request = http.request({
         method: 'POST',
         host: 'api.rollbar.com',
         path: '/api/1/deploy/',

--- a/package.json
+++ b/package.json
@@ -22,5 +22,7 @@
     "rollbar",
     "deployment"
   ],
-  "dependencies": {}
+  "dependencies": {
+    "follow-redirects": "^1.14.1"
+  }
 }


### PR DESCRIPTION
Previously we attempted a fix relying on using `https` lib to make the call, but this breaks. 

I've reverted that commit; using the redirect follow method does work.